### PR TITLE
Fix Crash on Paste

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/BlockSpec.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/BlockSpec.java
@@ -245,7 +245,7 @@ public class BlockSpec implements ImmutableBlockSpec {
                     }
                 }
 
-                if (stack2.getTagCompound().hasNoTags()) stack2.setTagCompound(null);
+                if (stack2.getTagCompound() != null && stack2.getTagCompound().hasNoTags()) stack2.setTagCompound(null);
             }
         }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -1217,10 +1217,6 @@ public class BlockPropertyRegistry {
             }
 
             setValue(tag, value);
-
-            if (tag.hasNoTags()) {
-                stack.setTagCompound(null);
-            }
         }
 
         public abstract JsonElement getValue(NBTTagCompound itemTag);


### PR DESCRIPTION
Removed redundant tag-clearing in `BlockPropertyRegistry#setValue()` (which caused the crash) and added null-check for `getTagCompound().hasNoTags()` for additional safety.

I believe this is also an issue with the original mod, not just the fork (though not 100% sure). 

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20621