### PR TITLE
fix gregtech detection to only work on NH's gregtech 5u

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -62,7 +62,7 @@ public enum Mods implements IMod {
         public static final String FLOOD_LIGHTS = "FloodLights";
         public static final String GALACTICRAFT_CORE = "GalacticraftCore";
         public static final String GALAXY_SPACE = "GalaxySpace";
-        public static final String GREG_TECH = "gregtech";
+        public static final String GREG_TECH = "gregtech_nh";
         public static final String GRAVI_SUITE = "GraviSuite";
         public static final String G_T_PLUS_PLUS = "miscutils";
         public static final String GTNH_INTERGALACTIC = "gtnhintergalactic";


### PR DESCRIPTION
it breaks with base gt5 or gt6 if you just detect "gregtech"
you have to detect gtnh's "gregtech_nh" modid (so that it also works without dreamcraft installed)