### PR TITLE
[MatterManipulator] Fix: Matter Manipulator voids half the slab it uses 

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/BlockSpec.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/BlockSpec.java
@@ -190,6 +190,9 @@ public class BlockSpec implements ImmutableBlockSpec {
 
             if (isBlock) {
                 stack = getBlock().createStackedBlock(metadata);
+                if (stack != null && Block.getBlockFromItem(stack.getItem()) == getBlock()) {
+                    stack.stackSize = 1;
+                }
             }
 
             if (stack == null || stack.getItem() == null) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
@@ -310,7 +310,7 @@ public class PendingBuild extends AbstractBuildable {
             if (!pending.spec.isAir()) {
                 Block block = pending.getBlock();
 
-                if (pending.getItem() instanceof ItemBlock itemBlock) {
+                if (pending.getItem() instanceof ItemBlock itemBlock && Block.getBlockFromItem(itemBlock) == block) {
                     itemBlock.placeBlockAt(
                         perBlock,
                         player,


### PR DESCRIPTION
This fixes 2 bugs:
- When copying a slab, it consumed 2 slabs even though there was only 1.
- When copying double slabs, it only copied the bottom one but still consumed 2.


closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22781