### PR TITLE
Fix copying Crafting Input Buffer manual slots with Matter Manipulator

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
@@ -14,6 +14,8 @@ import gregtech.api.metatileentity.implementations.MTEBasicBatteryBuffer;
 import gregtech.api.metatileentity.implementations.MTEHatchInputBus;
 import gregtech.api.metatileentity.implementations.MTEHatchOutputBus;
 import gregtech.api.metatileentity.implementations.MTEMultiBlockBase;
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputME;
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 import gregtech.common.tileentities.machines.outputme.MTEHatchOutputBusME;
 import gregtech.common.tileentities.machines.outputme.MTEHatchOutputME;
 
@@ -84,6 +86,8 @@ public enum InventoryAdapter {
                 if (imte instanceof MTEMultiBlockBase) return true;
                 if (imte instanceof MTEBasicBatteryBuffer) return true;
                 if (imte instanceof MTEHatchTurbine) return true;
+                if (imte instanceof MTEHatchCraftingInputME) return true;
+                if (imte instanceof MTEHatchCraftingInputSlave) return true;
             }
 
             return false;


### PR DESCRIPTION
before this error came: 
<img width="1360" height="554" alt="image" src="https://github.com/user-attachments/assets/87ddb173-b793-41ae-a3d5-4dd9ae783b34" />


now it works:
https://discord.com/channels/181078474394566657/181078474394566657/1495941664169132123