### PR TITLE
Implement `IItemProvider` for OpenComputer Components

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/InventoryAnalysis.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/InventoryAnalysis.java
@@ -10,6 +10,7 @@ import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentItemName;
 import com.recursive_pineapple.matter_manipulator.common.building.BlockAnalyzer.IBlockApplyContext;
 import com.recursive_pineapple.matter_manipulator.common.building.providers.AECellItemProvider;
 import com.recursive_pineapple.matter_manipulator.common.building.providers.BatteryItemProvider;
+import com.recursive_pineapple.matter_manipulator.common.building.providers.ComputerComponentItemProvider;
 import com.recursive_pineapple.matter_manipulator.common.building.providers.IItemProvider;
 import com.recursive_pineapple.matter_manipulator.common.building.providers.PatternItemProvider;
 import com.recursive_pineapple.matter_manipulator.common.utils.InventoryAdapter;
@@ -53,6 +54,11 @@ public class InventoryAnalysis {
 
     private static IItemProvider getProviderFor(ItemStack stack, boolean fuzzy) {
         if (stack == null || stack.getItem() == null) return null;
+
+        if (Mods.OpenComputers.isModLoaded()) {
+            IItemProvider component = ComputerComponentItemProvider.fromStack(stack);
+            if (component != null) return component;
+        }
 
         if (Mods.AppliedEnergistics2.isModLoaded()) {
             if (!fuzzy) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -83,7 +83,9 @@ public class ComputerComponentItemProvider implements IItemProvider {
 
         if (component.getItemDamage() == EEPROM.getItemDamage()) {
             // Prefer an exact matching EEPROM; otherwise program an empty one.
-            return inv.tryConsumeItems(component) || inv.tryConsumeItems(EEPROM) ? component.copy() : null;
+            BooleanObjectImmutablePair<List<BigItemStack>> result = inv
+                .tryConsumeItems(Collections.singletonList(BigItemStack.create(component)), IPseudoInventory.CONSUME_REAL_ONLY);
+            return result.leftBoolean() || inv.tryConsumeItems(EEPROM) ? component.copy() : null;
         }
 
         // HDDs and floppies are consumed empty; their data is not copied.

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -1,0 +1,95 @@
+package com.recursive_pineapple.matter_manipulator.common.building.providers;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import com.recursive_pineapple.matter_manipulator.common.building.IPseudoInventory;
+import com.recursive_pineapple.matter_manipulator.common.utils.BigItemStack;
+
+import org.jetbrains.annotations.Nullable;
+
+import it.unimi.dsi.fastutil.booleans.BooleanObjectImmutablePair;
+import li.cil.oc.api.API;
+import li.cil.oc.api.detail.ItemInfo;
+
+public class ComputerComponentItemProvider implements IItemProvider {
+
+    public ItemStack component;
+
+    public ComputerComponentItemProvider() {}
+
+    public static ComputerComponentItemProvider fromStack(ItemStack stack) {
+        if (stack == null) return null;
+
+        ItemInfo component = API.items.get(stack);
+
+        if (component == null) return null;
+
+        ComputerComponentItemProvider provider = new ComputerComponentItemProvider();
+
+        provider.component = stack;
+
+        return provider;
+    }
+
+    @Override
+    public @Nullable ItemStack getStack(IPseudoInventory inv, boolean consume) {
+        if (!consume) return component;
+
+        // any cpu, gpu, or ram can be used, even if it has assigned uuid
+        if (
+            component.getItemDamage() == API.items.get("cpu1").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("cpu2").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("cpu3").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("graphicsCard1").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("graphicsCard2").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("graphicsCard3").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("ram1").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("ram2").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("ram3").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("ram4").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("ram5").createItemStack(1).getItemDamage() ||
+                component.getItemDamage() == API.items.get("ram6").createItemStack(1).getItemDamage()
+        ) {
+            BooleanObjectImmutablePair<List<BigItemStack>> result = inv
+                .tryConsumeItems(Collections.singletonList(BigItemStack.create(component)), IPseudoInventory.CONSUME_FUZZY);
+            if (!result.leftBoolean()) return null;
+            return API.items.get(component).createItemStack(1);
+        }
+
+        // take a matching eeprom, or program an empty one
+        if (component.getItemDamage() == API.items.get("eeprom").createItemStack(1).getItemDamage()) {
+            ItemStack copiedEEPROM = API.items.get(component).createItemStack(1);
+
+            // copy all NBT from the source component, but strip the address
+            if (component.hasTagCompound()) {
+                NBTTagCompound tag = (NBTTagCompound) component.getTagCompound().copy();
+                if (tag.hasKey("oc:data")) {
+                    NBTTagCompound ocData = tag.getCompoundTag("oc:data");
+                    if (ocData.hasKey("node")) {
+                        NBTTagCompound node = ocData.getCompoundTag("node");
+                        node.removeTag("address");
+                        ocData.setTag("node", node);
+                    }
+                    tag.setTag("oc:data", ocData);
+                }
+                copiedEEPROM.setTagCompound(tag);
+            }
+
+            if (inv.tryConsumeItems(copiedEEPROM) || inv.tryConsumeItems(API.items.get("eeprom").createItemStack(1))) return copiedEEPROM;
+            return null;
+        }
+
+        return null;
+    }
+
+    @Override
+    public IItemProvider clone() {
+        ComputerComponentItemProvider provider = new ComputerComponentItemProvider();
+        provider.component = component;
+        return provider;
+    }
+}

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -123,8 +123,6 @@ public class ComputerComponentItemProvider implements IItemProvider {
         // Most OC components are equal by descriptor; assigned addresses do not matter.
         if (component.getItemDamage() != EEPROM.getItemDamage()) return API.items.get(component).equals(API.items.get(provider.component));
 
-        if (provider.component.getItemDamage() != EEPROM.getItemDamage()) return false;
-
         // EEPROMs must match exactly, except for their assigned OC address.
         return ItemStack.areItemStacksEqual(component, provider.component);
     }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -58,7 +58,7 @@ public class ComputerComponentItemProvider implements IItemProvider {
     private static final ItemStack HDD_3 = API.items.get("hdd3").createItemStack(1);
     private static final ItemStack FLOPPY = API.items.get("floppy").createItemStack(1);
 
-    private @NotNull ItemStack component;
+    private final @NotNull ItemStack component;
 
     public ComputerComponentItemProvider(@NotNull ItemStack component) {
         this.component = component;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -12,14 +12,15 @@ import net.minecraft.nbt.NBTTagCompound;
 import com.recursive_pineapple.matter_manipulator.common.building.IPseudoInventory;
 import com.recursive_pineapple.matter_manipulator.common.utils.BigItemStack;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import it.unimi.dsi.fastutil.booleans.BooleanObjectImmutablePair;
 import li.cil.oc.api.API;
-import li.cil.oc.api.detail.ItemInfo;
 
 public class ComputerComponentItemProvider implements IItemProvider {
 
+    /// Components where any matching tier/type is fine, even with an assigned address.
     private static final HashSet<Integer> FUZZY_COMPONENT_DAMAGE = Arrays.stream(new String[] {
         // spotless:off
         "cpu1",
@@ -51,29 +52,29 @@ public class ComputerComponentItemProvider implements IItemProvider {
         .map(name -> API.items.get(name).createItemStack(1).getItemDamage())
         .collect(Collectors.toCollection(HashSet::new));
 
-    public ItemStack component;
+    public static final ItemStack EEPROM = API.items.get("eeprom").createItemStack(1);
+    public static final ItemStack HDD_1 = API.items.get("hdd1").createItemStack(1);
+    public static final ItemStack HDD_2 = API.items.get("hdd2").createItemStack(1);
+    public static final ItemStack HDD_3 = API.items.get("hdd3").createItemStack(1);
+    public static final ItemStack FLOPPY = API.items.get("floppy").createItemStack(1);
 
-    public ComputerComponentItemProvider() {}
+    public @NotNull ItemStack component;
+
+    public ComputerComponentItemProvider(@NotNull ItemStack component) {
+        this.component = component;
+    }
 
     public static ComputerComponentItemProvider fromStack(ItemStack stack) {
         if (stack == null) return null;
-
-        ItemInfo component = API.items.get(stack);
-
-        if (component == null) return null;
-
-        ComputerComponentItemProvider provider = new ComputerComponentItemProvider();
-
-        provider.component = stack;
-
-        return provider;
+        if (API.items.get(stack) == null) return null;
+        return new ComputerComponentItemProvider(stack);
     }
 
     @Override
     public @Nullable ItemStack getStack(IPseudoInventory inv, boolean consume) {
         if (!consume) return component;
 
-        // any cpu, gpu, or ram can be used, even if it has assigned uuid
+        // Addressed components are consumed fuzzily, then recreated without copying their NBT.
         if (FUZZY_COMPONENT_DAMAGE.contains(component.getItemDamage())) {
             BooleanObjectImmutablePair<List<BigItemStack>> result = inv
                 .tryConsumeItems(Collections.singletonList(BigItemStack.create(component)), IPseudoInventory.CONSUME_FUZZY);
@@ -81,11 +82,10 @@ public class ComputerComponentItemProvider implements IItemProvider {
             return API.items.get(component).createItemStack(1);
         }
 
-        // take a matching eeprom, or program an empty one
-        if (component.getItemDamage() == API.items.get("eeprom").createItemStack(1).getItemDamage()) {
+        if (component.getItemDamage() == EEPROM.getItemDamage()) {
             ItemStack copiedEEPROM = API.items.get(component).createItemStack(1);
 
-            // copy all NBT from the source component, but strip the address
+            // Copy the programmed EEPROM data, but force OC to assign a fresh address.
             if (component.hasTagCompound()) {
                 NBTTagCompound tag = (NBTTagCompound) component.getTagCompound().copy();
                 if (tag.hasKey("oc:data")) {
@@ -98,42 +98,32 @@ public class ComputerComponentItemProvider implements IItemProvider {
                 copiedEEPROM.setTagCompound(tag);
             }
 
-            if (inv.tryConsumeItems(copiedEEPROM) || inv.tryConsumeItems(API.items.get("eeprom").createItemStack(1))) return copiedEEPROM;
-            return null;
+            // Prefer an exact matching EEPROM; otherwise program an empty one.
+            return inv.tryConsumeItems(copiedEEPROM) || inv.tryConsumeItems(EEPROM) ? copiedEEPROM : null;
         }
 
-        // take empty hdds, do not program them
-        // TODO: override equality so disks are equal whenever their tier is equal, regardless of content
-        if (component.getItemDamage() == API.items.get("hdd1").createItemStack(1).getItemDamage()) {
-            if (inv.tryConsumeItems(API.items.get("hdd1").createItemStack(1))) return API.items.get("hdd1").createItemStack(1);
-            return null;
-        }
-
-        if (component.getItemDamage() == API.items.get("hdd2").createItemStack(1).getItemDamage()) {
-            if (inv.tryConsumeItems(API.items.get("hdd2").createItemStack(1))) return API.items.get("hdd2").createItemStack(1);
-            return null;
-        }
-
-        if (component.getItemDamage() == API.items.get("hdd3").createItemStack(1).getItemDamage()) {
-            if (inv.tryConsumeItems(API.items.get("hdd3").createItemStack(1))) return API.items.get("hdd3").createItemStack(1);
-            return null;
-        }
+        // HDDs and floppies are consumed empty; their data is not copied.
+        if (component.getItemDamage() == HDD_1.getItemDamage()) return inv.tryConsumeItems(HDD_1) ? HDD_1.copy() : null;
+        if (component.getItemDamage() == HDD_2.getItemDamage()) return inv.tryConsumeItems(HDD_2) ? HDD_2.copy() : null;
+        if (component.getItemDamage() == HDD_3.getItemDamage()) return inv.tryConsumeItems(HDD_3) ? HDD_3.copy() : null;
+        if (component.getItemDamage() == FLOPPY.getItemDamage()) return inv.tryConsumeItems(FLOPPY) ? FLOPPY.copy() : null;
 
         return null;
     }
 
     @Override
     public IItemProvider clone() {
-        ComputerComponentItemProvider provider = new ComputerComponentItemProvider();
-        provider.component = component;
-        return provider;
+        return new ComputerComponentItemProvider(component);
     }
 
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof ComputerComponentItemProvider provider)) return false;
-        if (component.getItemDamage() != API.items.get("eeprom").createItemStack(1).getItemDamage()) return component.equals(provider.component);
-        if (provider.component.getItemDamage() != API.items.get("eeprom").createItemStack(1).getItemDamage()) return false;
+
+        // Most OC components are equal by descriptor; assigned addresses do not matter.
+        if (component.getItemDamage() != EEPROM.getItemDamage()) return API.items.get(component).equals(API.items.get(provider.component));
+
+        if (provider.component.getItemDamage() != EEPROM.getItemDamage()) return false;
 
         NBTTagCompound tagThis = (NBTTagCompound) component.getTagCompound().copy();
         NBTTagCompound tagOther = (NBTTagCompound) provider.component.getTagCompound().copy();
@@ -150,6 +140,7 @@ public class ComputerComponentItemProvider implements IItemProvider {
         NBTTagCompound nodeThis = dataThis.getCompoundTag("node");
         NBTTagCompound nodeOther = dataOther.getCompoundTag("node");
 
+        // EEPROMs must match exactly, except for their assigned OC address.
         nodeThis.removeTag("address");
         nodeOther.removeTag("address");
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -97,9 +97,14 @@ public class ComputerComponentItemProvider implements IItemProvider {
         return null;
     }
 
-    // Strips the address of EEPROMs. Might work for other components.
+    /// Strips the address of EEPROMs. Might work for other components.
     private static @NotNull ItemStack withoutAddress(@NotNull ItemStack source) {
         ItemStack stripped = source.copy();
+
+        if (stripped.getItemDamage() != EEPROM.getItemDamage()) {
+            stripped.setTagCompound(null);
+            return stripped;
+        }
 
         if (!stripped.hasTagCompound()) return stripped;
         NBTTagCompound tag = stripped.getTagCompound();
@@ -108,7 +113,7 @@ public class ComputerComponentItemProvider implements IItemProvider {
         NBTTagCompound data = tag.getCompoundTag("oc:data");
 
         if (!data.hasKey("node")) return stripped;
-        data.getCompoundTag("node").removeTag("address");
+        data.getCompoundTag("node").removeTag("address");;
 
         return stripped;
     }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -94,7 +94,7 @@ public class ComputerComponentItemProvider implements IItemProvider {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof ComputerComponentItemProvider provider)) return false;
-        if (component.getItemDamage() != API.items.get("eeprom").createItemStack(1).getItemDamage()) return super.equals(other);
+        if (component.getItemDamage() != API.items.get("eeprom").createItemStack(1).getItemDamage()) return component.equals(provider.component);
         if (provider.component.getItemDamage() != API.items.get("eeprom").createItemStack(1).getItemDamage()) return false;
 
         NBTTagCompound tagThis = (NBTTagCompound) component.getTagCompound().copy();

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -126,6 +126,6 @@ public class ComputerComponentItemProvider implements IItemProvider {
         if (provider.component.getItemDamage() != EEPROM.getItemDamage()) return false;
 
         // EEPROMs must match exactly, except for their assigned OC address.
-        return ItemStack.areItemStacksEqual(component, withoutAddress(provider.component));
+        return ItemStack.areItemStacksEqual(component, provider.component);
     }
 }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -68,13 +68,11 @@ public class ComputerComponentItemProvider implements IItemProvider {
             if (component.hasTagCompound()) {
                 NBTTagCompound tag = (NBTTagCompound) component.getTagCompound().copy();
                 if (tag.hasKey("oc:data")) {
-                    NBTTagCompound ocData = tag.getCompoundTag("oc:data");
-                    if (ocData.hasKey("node")) {
-                        NBTTagCompound node = ocData.getCompoundTag("node");
+                    NBTTagCompound data = tag.getCompoundTag("oc:data");
+                    if (data.hasKey("node")) {
+                        NBTTagCompound node = data.getCompoundTag("node");
                         node.removeTag("address");
-                        ocData.setTag("node", node);
                     }
-                    tag.setTag("oc:data", ocData);
                 }
                 copiedEEPROM.setTagCompound(tag);
             }
@@ -91,5 +89,32 @@ public class ComputerComponentItemProvider implements IItemProvider {
         ComputerComponentItemProvider provider = new ComputerComponentItemProvider();
         provider.component = component;
         return provider;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ComputerComponentItemProvider provider)) return false;
+        if (component.getItemDamage() != API.items.get("eeprom").createItemStack(1).getItemDamage()) return super.equals(other);
+        if (provider.component.getItemDamage() != API.items.get("eeprom").createItemStack(1).getItemDamage()) return false;
+
+        NBTTagCompound tagThis = (NBTTagCompound) component.getTagCompound().copy();
+        NBTTagCompound tagOther = (NBTTagCompound) provider.component.getTagCompound().copy();
+
+        if (!tagThis.hasKey("oc:data")) return false;
+        if (!tagOther.hasKey("oc:data")) return false;
+
+        NBTTagCompound dataThis = tagThis.getCompoundTag("oc:data");
+        NBTTagCompound dataOther = tagOther.getCompoundTag("oc:data");
+
+        if (!dataThis.hasKey("node")) return false;
+        if (!dataOther.hasKey("node")) return false;
+
+        NBTTagCompound nodeThis = dataThis.getCompoundTag("node");
+        NBTTagCompound nodeOther = dataOther.getCompoundTag("node");
+
+        nodeThis.removeTag("address");
+        nodeOther.removeTag("address");
+
+        return tagThis.equals(tagOther);
     }
 }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -1,7 +1,10 @@
 package com.recursive_pineapple.matter_manipulator.common.building.providers;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,6 +19,37 @@ import li.cil.oc.api.API;
 import li.cil.oc.api.detail.ItemInfo;
 
 public class ComputerComponentItemProvider implements IItemProvider {
+
+    private static final HashSet<Integer> FUZZY_COMPONENT_DAMAGE = Arrays.stream(new String[] {
+        // spotless:off
+        "cpu1",
+        "cpu2",
+        "cpu3",
+        "dataCard1",
+        "dataCard2",
+        "dataCard3",
+        "internetCard",
+        "lanCard",
+        "wlanCard1",
+        "wlanCard2",
+        "linkedCard",
+        "redstoneCard1",
+        "redstoneCard2",
+        "tpsCard",
+        "debugCard",
+        "graphicsCard1",
+        "graphicsCard2",
+        "graphicsCard3",
+        "ram1",
+        "ram2",
+        "ram3",
+        "ram4",
+        "ram5",
+        "ram6"
+        // spotless:on
+    })
+        .map(name -> API.items.get(name).createItemStack(1).getItemDamage())
+        .collect(Collectors.toCollection(HashSet::new));
 
     public ItemStack component;
 
@@ -40,20 +74,7 @@ public class ComputerComponentItemProvider implements IItemProvider {
         if (!consume) return component;
 
         // any cpu, gpu, or ram can be used, even if it has assigned uuid
-        if (
-            component.getItemDamage() == API.items.get("cpu1").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("cpu2").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("cpu3").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("graphicsCard1").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("graphicsCard2").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("graphicsCard3").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("ram1").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("ram2").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("ram3").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("ram4").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("ram5").createItemStack(1).getItemDamage() ||
-                component.getItemDamage() == API.items.get("ram6").createItemStack(1).getItemDamage()
-        ) {
+        if (FUZZY_COMPONENT_DAMAGE.contains(component.getItemDamage())) {
             BooleanObjectImmutablePair<List<BigItemStack>> result = inv
                 .tryConsumeItems(Collections.singletonList(BigItemStack.create(component)), IPseudoInventory.CONSUME_FUZZY);
             if (!result.leftBoolean()) return null;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -52,13 +52,13 @@ public class ComputerComponentItemProvider implements IItemProvider {
         .map(name -> API.items.get(name).createItemStack(1).getItemDamage())
         .collect(Collectors.toCollection(HashSet::new));
 
-    public static final ItemStack EEPROM = API.items.get("eeprom").createItemStack(1);
-    public static final ItemStack HDD_1 = API.items.get("hdd1").createItemStack(1);
-    public static final ItemStack HDD_2 = API.items.get("hdd2").createItemStack(1);
-    public static final ItemStack HDD_3 = API.items.get("hdd3").createItemStack(1);
-    public static final ItemStack FLOPPY = API.items.get("floppy").createItemStack(1);
+    private static final ItemStack EEPROM = API.items.get("eeprom").createItemStack(1);
+    private static final ItemStack HDD_1 = API.items.get("hdd1").createItemStack(1);
+    private static final ItemStack HDD_2 = API.items.get("hdd2").createItemStack(1);
+    private static final ItemStack HDD_3 = API.items.get("hdd3").createItemStack(1);
+    private static final ItemStack FLOPPY = API.items.get("floppy").createItemStack(1);
 
-    public @NotNull ItemStack component;
+    private @NotNull ItemStack component;
 
     public ComputerComponentItemProvider(@NotNull ItemStack component) {
         this.component = component;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -67,7 +67,7 @@ public class ComputerComponentItemProvider implements IItemProvider {
     public static ComputerComponentItemProvider fromStack(ItemStack stack) {
         if (stack == null) return null;
         if (API.items.get(stack) == null) return null;
-        return new ComputerComponentItemProvider(stack);
+        return new ComputerComponentItemProvider(withoutAddress(stack));
     }
 
     @Override
@@ -78,28 +78,12 @@ public class ComputerComponentItemProvider implements IItemProvider {
         if (FUZZY_COMPONENT_DAMAGE.contains(component.getItemDamage())) {
             BooleanObjectImmutablePair<List<BigItemStack>> result = inv
                 .tryConsumeItems(Collections.singletonList(BigItemStack.create(component)), IPseudoInventory.CONSUME_FUZZY);
-            if (!result.leftBoolean()) return null;
-            return API.items.get(component).createItemStack(1);
+            return result.leftBoolean() ? API.items.get(component).createItemStack(1) : null;
         }
 
         if (component.getItemDamage() == EEPROM.getItemDamage()) {
-            ItemStack copiedEEPROM = API.items.get(component).createItemStack(1);
-
-            // Copy the programmed EEPROM data, but force OC to assign a fresh address.
-            if (component.hasTagCompound()) {
-                NBTTagCompound tag = (NBTTagCompound) component.getTagCompound().copy();
-                if (tag.hasKey("oc:data")) {
-                    NBTTagCompound data = tag.getCompoundTag("oc:data");
-                    if (data.hasKey("node")) {
-                        NBTTagCompound node = data.getCompoundTag("node");
-                        node.removeTag("address");
-                    }
-                }
-                copiedEEPROM.setTagCompound(tag);
-            }
-
             // Prefer an exact matching EEPROM; otherwise program an empty one.
-            return inv.tryConsumeItems(copiedEEPROM) || inv.tryConsumeItems(EEPROM) ? copiedEEPROM : null;
+            return inv.tryConsumeItems(component) || inv.tryConsumeItems(EEPROM) ? component.copy() : null;
         }
 
         // HDDs and floppies are consumed empty; their data is not copied.
@@ -109,6 +93,22 @@ public class ComputerComponentItemProvider implements IItemProvider {
         if (component.getItemDamage() == FLOPPY.getItemDamage()) return inv.tryConsumeItems(FLOPPY) ? FLOPPY.copy() : null;
 
         return null;
+    }
+
+    // Strips the address of EEPROMs. Might work for other components.
+    private static @NotNull ItemStack withoutAddress(@NotNull ItemStack source) {
+        ItemStack stripped = source.copy();
+
+        if (!stripped.hasTagCompound()) return stripped;
+        NBTTagCompound tag = stripped.getTagCompound();
+
+        if (!tag.hasKey("oc:data")) return stripped;
+        NBTTagCompound data = tag.getCompoundTag("oc:data");
+
+        if (!data.hasKey("node")) return stripped;
+        data.getCompoundTag("node").removeTag("address");
+
+        return stripped;
     }
 
     @Override
@@ -125,25 +125,7 @@ public class ComputerComponentItemProvider implements IItemProvider {
 
         if (provider.component.getItemDamage() != EEPROM.getItemDamage()) return false;
 
-        NBTTagCompound tagThis = (NBTTagCompound) component.getTagCompound().copy();
-        NBTTagCompound tagOther = (NBTTagCompound) provider.component.getTagCompound().copy();
-
-        if (!tagThis.hasKey("oc:data")) return false;
-        if (!tagOther.hasKey("oc:data")) return false;
-
-        NBTTagCompound dataThis = tagThis.getCompoundTag("oc:data");
-        NBTTagCompound dataOther = tagOther.getCompoundTag("oc:data");
-
-        if (!dataThis.hasKey("node")) return false;
-        if (!dataOther.hasKey("node")) return false;
-
-        NBTTagCompound nodeThis = dataThis.getCompoundTag("node");
-        NBTTagCompound nodeOther = dataOther.getCompoundTag("node");
-
         // EEPROMs must match exactly, except for their assigned OC address.
-        nodeThis.removeTag("address");
-        nodeOther.removeTag("address");
-
-        return tagThis.equals(tagOther);
+        return ItemStack.areItemStacksEqual(component, withoutAddress(provider.component));
     }
 }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/ComputerComponentItemProvider.java
@@ -102,6 +102,23 @@ public class ComputerComponentItemProvider implements IItemProvider {
             return null;
         }
 
+        // take empty hdds, do not program them
+        // TODO: override equality so disks are equal whenever their tier is equal, regardless of content
+        if (component.getItemDamage() == API.items.get("hdd1").createItemStack(1).getItemDamage()) {
+            if (inv.tryConsumeItems(API.items.get("hdd1").createItemStack(1))) return API.items.get("hdd1").createItemStack(1);
+            return null;
+        }
+
+        if (component.getItemDamage() == API.items.get("hdd2").createItemStack(1).getItemDamage()) {
+            if (inv.tryConsumeItems(API.items.get("hdd2").createItemStack(1))) return API.items.get("hdd2").createItemStack(1);
+            return null;
+        }
+
+        if (component.getItemDamage() == API.items.get("hdd3").createItemStack(1).getItemDamage()) {
+            if (inv.tryConsumeItems(API.items.get("hdd3").createItemStack(1))) return API.items.get("hdd3").createItemStack(1);
+            return null;
+        }
+
         return null;
     }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -55,6 +55,7 @@ public enum Mods implements IMod, ITargetMod {
     },
     NewHorizonsCoreMod(Names.NEW_HORIZONS_CORE_MOD),
     NotEnoughItems(Names.NOT_ENOUGH_ITEMS),
+    OpenComputers(Names.OPEN_COMPUTERS),
     StorageDrawers(Names.STORAGE_DRAWERS),
     Thaumcraft(Names.THAUMCRAFT),
 
@@ -90,6 +91,7 @@ public enum Mods implements IMod, ITargetMod {
         public static final String MINECRAFT = "minecraft";
         public static final String NEW_HORIZONS_CORE_MOD = "dreamcraft";
         public static final String NOT_ENOUGH_ITEMS = "NotEnoughItems";
+        public static final String OPEN_COMPUTERS = "OpenComputers";
         public static final String STORAGE_DRAWERS = "StorageDrawers";
         public static final String THAUMCRAFT = "Thaumcraft";
     }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -56,7 +56,6 @@ public enum Mods implements IMod, ITargetMod {
     },
     NewHorizonsCoreMod(Names.NEW_HORIZONS_CORE_MOD),
     NotEnoughItems(Names.NOT_ENOUGH_ITEMS),
-    OpenComputers(Names.OPEN_COMPUTERS),
     StorageDrawers(Names.STORAGE_DRAWERS),
     Thaumcraft(Names.THAUMCRAFT),
 
@@ -93,7 +92,6 @@ public enum Mods implements IMod, ITargetMod {
         public static final String OPEN_COMPUTERS = "OpenComputers";
         public static final String NEW_HORIZONS_CORE_MOD = "dreamcraft";
         public static final String NOT_ENOUGH_ITEMS = "NotEnoughItems";
-        public static final String OPEN_COMPUTERS = "OpenComputers";
         public static final String STORAGE_DRAWERS = "StorageDrawers";
         public static final String THAUMCRAFT = "Thaumcraft";
     }


### PR DESCRIPTION
This implementation handles most OpenComputers components fuzzily. It consumes a matching component, creates a fresh `ItemStack`, and lets it receive a new address. The exceptions are EEPROMs, HDDs and floppies. EEPROM data is small, up to 4 KB, so programmed EEPROMs can be matched directly, or their data can be copied onto an empty EEPROM when needed. HDDs and floppies must be empty to be pasted, since copying their contents would have a much larger memory footprint, up to 4 MB.

It currently is not possible to paste addressed EEPROMs, HDDs and floppies. However, it is simple to strip the address from EEPROMs by re-crafting it.