### PR TITLE
Fix IllegalAccessError for MTEHatch Amperes field

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,55 +38,55 @@ def asmVersion = "9.7"
 
 dependencies {
     implementation("com.github.GTNewHorizons:StructureLib:1.4.34:dev")
-    implementation("com.github.GTNewHorizons:ModularUI:1.3.2:dev")
-    implementation("com.github.GTNewHorizons:ModularUI2:2.3.51-1.7.10:dev")
-    implementation("com.github.GTNewHorizons:GTNHLib:0.9.47:dev")
+    implementation("com.github.GTNewHorizons:ModularUI:1.3.4:dev")
+    implementation("com.github.GTNewHorizons:ModularUI2:2.3.59-1.7.10:dev")
+    implementation("com.github.GTNewHorizons:GTNHLib:0.9.57:dev")
 
-    compileOnly("com.github.GTNewHorizons:ae2stuff:0.10.17-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.64-gtnh:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-882-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ae2stuff:0.10.19-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.80-gtnh:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-922-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ArchitectureCraft:1.12.10") { transitive = false }
     compileOnly("com.github.GTNewHorizons:CarpentersBlocks:3.7.2-GTNH") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Avaritia:1.93:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Avaritia:1.96:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.9.4-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:bdlib:1.11.0-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BloodMagic:1.8.14:dev") { transitive = false }
     compileOnly("curse.maven:cofh-lib-220333:2388748") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:EnderIO:2.10.22:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:EnderIO:2.10.25:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:EnderStorage:1.8.3:dev") { transitive = false }
     compileOnly(rfg.deobf("curse.maven:extra-utilities-225561:2264384"))
-    compileOnly("com.github.GTNewHorizons:FloodLights:1.5.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.7.3:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.399:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.7.116:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:FloodLights:1.5.6:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.7.10:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.476:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.7.133:dev") { transitive = false }
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev") { transitive = false }
     compileOnly("curse.maven:mekanism-268560:2475797") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.84-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:OpenComputers:1.12.22-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:OpenComputers:1.12.38-GTNH:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:waila:1.19.22:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:waila:1.19.24:dev") { transitive = false }
 
     compileOnly rfg.deobf("maven.modrinth:immibis-microblocks:59.1.2")
     compileOnly rfg.deobf("maven.modrinth:immibis-core:59.1.4")
 
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ae2stuff:0.10.17-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ae2stuff:0.10.19-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchitectureCraft:1.12.10")
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.15:dev')
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-882-GTNH:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Avaritia:1.93:dev")
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.19:dev')
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-922-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Avaritia:1.96:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Avaritiaddons:1.9.4-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.4.2:dev")
-//    runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.22:dev')
+//    runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.25:dev')
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderStorage:1.8.3:dev")
     runtimeOnlyNonPublishable(rfg.deobf("curse.maven:extra-utilities-225561:2264384"))
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.399:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:FloodLights:1.5.5:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForgeMultipart:1.7.3:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.116:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.476:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:FloodLights:1.5.6:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForgeMultipart:1.7.10:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.133:dev")
     runtimeOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.84-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")
     runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:WanionLib:1.10.0:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:WanionLib:1.10.1:dev")
 
     compileOnly("com.google.auto.value:auto-value-annotations:1.10.1") { transitive = false }
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")
@@ -109,7 +109,7 @@ project.getConfigurations()
         final DependencySubstitutions ds = c.getResolutionStrategy()
             .getDependencySubstitution();
         ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
-            .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH"))
+            .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.14-GTNH"))
             .withClassifier("dev")
             .because("Baubles-Expanded replaces Baubles");
     });

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/GTAnalysisResult.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/GTAnalysisResult.java
@@ -255,11 +255,11 @@ public class GTAnalysisResult implements ITileAnalysisIntegration {
         }
 
         if (mte instanceof MTEHatchEnergyTunnel hatch) {
-            mAmperes = hatch.Amperes;
+            mAmperes = hatch.getAmperes();
         }
 
         if (mte instanceof MTEHatchDynamoTunnel dynamo) {
-            mAmperes = dynamo.Amperes;
+            mAmperes = dynamo.getAmperes();
         }
 
         if (mte instanceof IMEConnectable me && me.connectsToAllSides()) {
@@ -486,11 +486,11 @@ public class GTAnalysisResult implements ITileAnalysisIntegration {
             }
 
             if (mAmperes > 0 && mte instanceof MTEHatchEnergyTunnel hatch) {
-                hatch.Amperes = MMUtils.clamp(mAmperes, 0, hatch.maxAmperes);
+                hatch.setAmperes(MMUtils.clamp(mAmperes, 0, hatch.maxAmperes));
             }
 
             if (mAmperes > 0 && mte instanceof MTEHatchDynamoTunnel dynamo) {
-                dynamo.Amperes = MMUtils.clamp(mAmperes, 0, dynamo.maxAmperes);
+                dynamo.setAmperes(MMUtils.clamp(mAmperes, 0, dynamo.maxAmperes));
             }
 
             if (mte instanceof IMEConnectable me) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/uplink/MTEMMUplink.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/uplink/MTEMMUplink.java
@@ -34,7 +34,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import gregtech.api.enums.Materials;
-import gregtech.api.enums.StructureError;
 import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.IIconContainer;
@@ -54,6 +53,7 @@ import gregtech.api.structure.IStructureProvider;
 import gregtech.api.structure.StructureWrapper;
 import gregtech.api.structure.StructureWrapperInstanceInfo;
 import gregtech.api.structure.StructureWrapperTooltipBuilder;
+import gregtech.api.structure.error.StructureError;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.IGTHatchAdder;
@@ -170,21 +170,10 @@ public class MTEMMUplink extends MTEExtendedPowerMultiBlockBase<MTEMMUplink> imp
     }
 
     @Override
-    protected void validateStructure(Collection<StructureError> errors, NBTTagCompound context) {
-        super.validateStructure(errors, context);
+    protected void validateStructure(Collection<StructureError> errors) {
+        super.validateStructure(errors);
 
-        structureInstanceInfo.validate(errors, context);
-    }
-
-    @Override
-    protected void localizeStructureErrors(
-        Collection<StructureError> errors,
-        NBTTagCompound context,
-        List<String> lines
-    ) {
-        super.localizeStructureErrors(errors, context, lines);
-
-        structureInstanceInfo.localizeStructureErrors(errors, context, lines);
+        structureInstanceInfo.validate(errors);
     }
 
     private enum UplinkHatchAdder implements IHatchElement<MTEMMUplink> {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
@@ -59,7 +59,7 @@ public enum InventoryAdapter {
             IGregTechTileEntity igte = (IGregTechTileEntity) inv;
             MTEHatchRack rack = (MTEHatchRack) igte.getMetaTileEntity();
 
-            if (rack.heat > 2000) {
+            if (rack.getHeat() > 2000) {
                 context.error(new ChatComponentTranslation("mm.info.error.qc_rack_is_too_hot"));
                 return false;
             }


### PR DESCRIPTION
Fixes a crash when using the Matter Manipulator to copy energy tunnel hatches on servers running older versions of GT5-Unofficial where `MTEHatchEnergyMulti.Amperes` was a `protected` field rather than `public`.

https://mclo.gs/MlqY5W2
