### PR TITLE
Prevent some modes from bypassing grief protection

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
@@ -19,8 +19,11 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidBlock;
@@ -432,10 +435,21 @@ public abstract class AbstractBuildable extends MMInventory implements IBuildabl
     /**
      * Checks if a block can be edited.
      */
-    protected boolean isEditable(World world, int x, int y, int z) {
+    protected boolean isEditable(World world, int x, int y, int z, boolean isPlacement) {
+        boolean isBlocked;
+        if (isPlacement) {
+            isBlocked = ForgeEventFactory.onPlayerBlockPlace(
+                player,
+                new BlockSnapshot(world, x, y, z, world.getBlock(x, y, z), world.getBlockMetadata(x, y, z)),
+                ForgeDirection.UNKNOWN
+            ).isCanceled();
+        } else {
+            isBlocked = MinecraftForge.EVENT_BUS
+                .post(new BlockEvent.BreakEvent(x, y, z, world, world.getBlock(x, y, z), world.getBlockMetadata(x, y, z), player));
+        }
         // if this block is protected, ignore it completely and print a warning
         // spotless:off
-        if (!world.canMineBlock(player, x, y, z) || MinecraftServer.getServer().isBlockProtected(world, x, y, z, player)) {
+        if (isBlocked || !world.canMineBlock(player, x, y, z) || MinecraftServer.getServer().isBlockProtected(world, x, y, z, player)) {
             // spotless:on
             if (!printedProtectedBlockWarning) {
                 sendWarningToPlayer(

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
@@ -122,7 +122,7 @@ public class PendingBuild extends AbstractBuildable {
             }
 
             // if this block is protected, ignore it completely and print a warning
-            if (!isEditable(world, x, y, z)) {
+            if (!isEditable(world, x, y, z, true)) {
                 pendingBlocks.removeFirst();
                 continue;
             }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingMove.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingMove.java
@@ -108,7 +108,7 @@ public class PendingMove extends AbstractBuildable {
             Location d = move.right();
 
             // if either block is protected, ignore them completely and print a warning
-            if (!isEditable(world, s.x, s.y, s.z) || !isEditable(world, d.x, d.y, d.z)) {
+            if (!isEditable(world, s.x, s.y, s.z, false) || !isEditable(world, d.x, d.y, d.z, true)) {
                 sendErrorToPlayer(
                     player,
                     "mm.info.error.could_not_move_protected_block.new",


### PR DESCRIPTION
Sending the BlockEvents allows grief protection from other mods to work.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22410