### PR TITLE
Fix crash when replacing CRIBs with proxies with ghost circuit set

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/GTAnalysisResult.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/GTAnalysisResult.java
@@ -387,14 +387,18 @@ public class GTAnalysisResult implements ITileAnalysisIntegration {
 
             // set the ghost circuit
             if (mte instanceof IConfigurationCircuitSupport ghostCircuit && ghostCircuit.allowSelectCircuit()) {
-                ItemStack circuit = null;
+                int circuitSlot = ghostCircuit.getCircuitSlot();
 
-                if (mGTGhostCircuit > 0) {
-                    circuit = ItemList.Circuit_Integrated.getWithDamage(0, mGTGhostCircuit);
+                if (circuitSlot >= 0 && circuitSlot < mte.getSizeInventory()) {
+                    ItemStack circuit = null;
+
+                    if (mGTGhostCircuit > 0) {
+                        circuit = ItemList.Circuit_Integrated.getWithDamage(0, mGTGhostCircuit);
+                    }
+
+                    mte.setInventorySlotContents(circuitSlot, circuit);
+                    mte.markDirty();
                 }
-
-                mte.setInventorySlotContents(ghostCircuit.getCircuitSlot(), circuit);
-                mte.markDirty();
             }
 
             // set the various input bus options

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
@@ -448,6 +448,7 @@ public class MMState {
 
             GTAnalysisResult gtResult = block.gt instanceof GTAnalysisResult ? (GTAnalysisResult) block.gt : new GTAnalysisResult();
             gtResult.mGTData = MMUtils.toJsonObject(proxyData);
+            gtResult.mGTGhostCircuit = 0;
             block.gt = gtResult;
 
             block.ae = null;


### PR DESCRIPTION
When "Replace CRIBs with Proxies" is enabled and the original CRIB has a ghost circuit configured, the Matter Manipulator crashes with ArrayIndexOutOfBoundsException: Index 144 out of bounds for length 0. This happens because the GTAnalysisResult from the CRIB is kept when the CRIB is substituted with a proxy, and the proxy (MTEHatchCraftingInputSlave) has 0 inventory slots but inherits allowSelectCircuit() = true from MTEHatchInputBus. The fix clears the ghost circuit data when CRIBs are substituted with proxies and adds a bounds check in GTAnalysisResult.apply() to prevent similar issues.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25050