### PR TITLE
Fix MM pulling patterns from Arcane Assembler as if they were items

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -124,6 +124,7 @@ dependencies {
     addCompat(oc, "com.github.GTNewHorizons:OpenComputers:1.12.48-GTNH:dev")
 
     addCompat(tc, "thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
+    addCompat(tc, "com.github.GTNewHorizons:ThaumicEnergistics:1.7.56-GTNH:dev")
 
     addCompat(waila, "com.github.GTNewHorizons:waila:1.19.30:dev")
 }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
@@ -27,6 +27,8 @@ import com.recursive_pineapple.matter_manipulator.mixin.interfaces.MTELinkedInpu
 
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchTurbine;
 import tectech.thing.metaTileEntity.hatch.MTEHatchRack;
+import thaumicenergistics.common.inventory.HandlerKnowledgeCore;
+import thaumicenergistics.common.tiles.TileArcaneAssembler;
 
 public enum InventoryAdapter {
 
@@ -195,6 +197,21 @@ public enum InventoryAdapter {
         @Override
         public boolean insert(IInventory inv, int slot, ItemStack stack) {
             return ((IHasInventory) inv).addStackToSlot(slot, stack);
+        }
+    },
+    @Optional(Names.THAUMIC_ENERGISTICS)
+    TEArcaneAssembler {
+
+        @Override
+        public boolean canHandle(IInventory inv) {
+            return inv instanceof TileArcaneAssembler;
+        }
+
+        @Override
+        public boolean isValidSlot(IInventory inv, int slot) {
+            int patternSlotIndex = TileArcaneAssembler.PATTERN_SLOT_INDEX;
+            boolean isPatternSlot = slot >= patternSlotIndex && slot < patternSlotIndex + HandlerKnowledgeCore.MAXIMUM_STORED_PATTERNS;
+            return !isPatternSlot;
         }
     },
     SIDED {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
@@ -209,8 +209,8 @@ public enum InventoryAdapter {
 
         @Override
         public boolean isValidSlot(IInventory inv, int slot) {
-            int patternSlotIndex = TileArcaneAssembler.PATTERN_SLOT_INDEX;
-            boolean isPatternSlot = slot >= patternSlotIndex && slot < patternSlotIndex + HandlerKnowledgeCore.MAXIMUM_STORED_PATTERNS;
+            boolean isPatternSlot = slot >= TileArcaneAssembler.PATTERN_SLOT_INDEX &&
+                slot < TileArcaneAssembler.PATTERN_SLOT_INDEX + HandlerKnowledgeCore.MAXIMUM_STORED_PATTERNS;
             return !isPatternSlot;
         }
     },

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -92,6 +92,7 @@ public enum Mods implements IMod, ITargetMod {
         public static final String NOT_ENOUGH_ITEMS = "NotEnoughItems";
         public static final String STORAGE_DRAWERS = "StorageDrawers";
         public static final String THAUMCRAFT = "Thaumcraft";
+        public static final String THAUMIC_ENERGISTICS = "thaumicenergistics";
     }
 
     public final String ID;


### PR DESCRIPTION
## Summary
The "ghost" pattern items in the arcane assembler were being treated like normal items in an inventory and being removed when the arcane assembler was removed by a MM. This PR adds an inventory adapter to ignore the pattern slots.
Closes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/326

## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
