### PR TITLE
Move Mode Edit Transform Option

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/ItemMatterManipulator.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/ItemMatterManipulator.java
@@ -1180,7 +1180,7 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
                 switch (initialState.config.placeMode) {
                     case GEOMETRY -> addGeometryOptions(builder, buildContext, heldStack, initialState);
                     case COPYING -> addCopyingOptions(builder, buildContext, heldStack, initialState);
-                    case MOVING -> addMovingOptions(builder, buildContext, heldStack);
+                    case MOVING -> addMovingOptions(builder, buildContext, heldStack, initialState);
                     case EXCHANGING -> addExchangingOptions(builder, buildContext, heldStack);
                     case CABLES -> addCableOptions(builder, buildContext, heldStack);
                 }
@@ -1441,7 +1441,7 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
                 .label(StatCollector.translateToLocal("mm.gui.edit_transform"))
                 .onClicked((menu, option, mouseButton, doubleClicked) -> {
                     UIBuildContext buildContext2 = new UIBuildContext(buildContext.getPlayer());
-                    ModularWindow window = createTransformWindow(buildContext2, heldStack, initialState);
+                    ModularWindow window = createCopyModeTransformWindow(buildContext2, heldStack, initialState);
                     GuiScreen screen = new TransparentModularGui(
                             new ModularUIContainer(new ModularUIContext(buildContext2, null, true), window));
                     FMLCommonHandler.instance().showGuiScreen(screen);
@@ -1492,7 +1492,7 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
         public void drawDefaultBackground() {}
     }
 
-    private void addMovingOptions(RadialMenuBuilder builder, UIBuildContext buildContext, ItemStack heldStack) {
+    private void addMovingOptions(RadialMenuBuilder builder, UIBuildContext buildContext, ItemStack heldStack, MMState initialState) {
         builder
             .option()
                 .label(StatCollector.translateToLocal("mm.gui.mark_cut"))
@@ -1504,6 +1504,16 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
                 .label(StatCollector.translateToLocal("mm.gui.mark_paste"))
                 .onClicked(() -> {
                     Messages.MarkPaste.sendToServer();
+                })
+            .done()
+            .option()
+                .label(StatCollector.translateToLocal("mm.gui.edit_transform"))
+                .onClicked((menu, option, mouseButton, doubleClicked) -> {
+                    UIBuildContext buildContext2 = new UIBuildContext(buildContext.getPlayer());
+                    ModularWindow window = createMoveModeTransformWindow(buildContext2, heldStack, initialState);
+                    GuiScreen screen = new TransparentModularGui(
+                        new ModularUIContainer(new ModularUIContext(buildContext2, null, true), window));
+                    FMLCommonHandler.instance().showGuiScreen(screen);
                 })
             .done();
     }
@@ -1612,8 +1622,8 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
         return new Row().setSize(width, height);
     }
 
-    public ModularWindow createTransformWindow(UIBuildContext buildContext, ItemStack heldStack,
-        MMState initialState) {
+    public ModularWindow createCopyModeTransformWindow(UIBuildContext buildContext, ItemStack heldStack,
+                                                       MMState initialState) {
         buildContext.setShowNEI(false);
 
         ModularWindow.Builder builder = ModularWindow.builderFullScreen();
@@ -1829,6 +1839,132 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
                     new Column()
                         .setAlignment(MainAxisAlignment.CENTER, CrossAxisAlignment.START)
                         .widgets(left)).fillParent());
+
+            Column columnRight, columnLessRight;
+
+            builder.widget(
+                (columnRight = new Column())
+                    .setAlignment(MainAxisAlignment.CENTER, CrossAxisAlignment.END)
+                    .widgets(right)
+                    .setPosProvider((screenSize, window, parent) -> {
+                        return new Pos2d(screenSize.width - columnRight.getSize().width - 10, 0);
+                    }));
+
+            builder.widget(
+                (columnLessRight = new Column())
+                    .setAlignment(MainAxisAlignment.CENTER, CrossAxisAlignment.END)
+                    .widgets(lessRight)
+                    .setPosProvider((screenSize, window, parent) -> {
+                        return new Pos2d(screenSize.width - columnRight.getSize().width - columnLessRight.getSize().width - 20, 0);
+                    }));
+        }
+
+        return builder.build();
+    }
+
+    public ModularWindow createMoveModeTransformWindow(UIBuildContext buildContext, ItemStack heldStack,
+                                                       MMState initialState) {
+        buildContext.setShowNEI(false);
+
+        ModularWindow.Builder builder = ModularWindow.builderFullScreen();
+
+        builder.bindPlayerInventory(buildContext.getPlayer(), 0, -9001);
+
+        if (NetworkUtils.isClient()) {
+            Widget[] right, lessRight;
+
+            if (Minecraft.getMinecraft().gameSettings.guiScale <= 2) {
+                right = new Widget[]{
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.copy_a")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyA, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyA, CoordComponent.Y),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyA, CoordComponent.Z),
+                    padding(10, 2),
+
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.copy_b")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyB, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyB, CoordComponent.Y),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyB, CoordComponent.Z),
+                    padding(10, 2),
+
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.copy")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Copy, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Copy, CoordComponent.Y),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Copy, CoordComponent.Z),
+                    padding(10, 2),
+
+                    new Row()
+                        .widget(new VanillaButtonWidget().setDisplayString(StatCollector.translateToLocal("mm.transform.button.swap"))
+                        .setOnClick((t, u) -> { Messages.SwapRegion.sendToServer(); })
+                        .setSynced(false, false)
+                        .setSize(130, 18)),
+                    padding(10, 2),
+
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.paste")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Paste, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Paste, CoordComponent.Y),
+                    padding(10, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Paste, CoordComponent.Z),
+                };
+
+                lessRight = new Widget[0];
+            } else {
+                right = new Widget[]{
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.copy")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Copy, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Copy, CoordComponent.Y),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Copy, CoordComponent.Z),
+                    padding(10, 2),
+
+                    new Row()
+                        .widget(new VanillaButtonWidget().setDisplayString(StatCollector.translateToLocal("mm.transform.button.swap"))
+                        .setOnClick((t, u) -> { Messages.SwapRegion.sendToServer(); })
+                        .setSynced(false, false)
+                        .setSize(130, 18)),
+                    padding(10, 2),
+
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.paste")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Paste, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Paste, CoordComponent.Y),
+                    padding(10, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.Paste, CoordComponent.Z),
+                };
+
+                lessRight = new Widget[]{
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.copy_a")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyA, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyA, CoordComponent.Y),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyA, CoordComponent.Z),
+                    padding(2, 2),
+
+                    makeHeader(StatCollector.translateToLocal("mm.transform.header.copy_b")),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyB, CoordComponent.X),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyB, CoordComponent.Y),
+                    padding(2, 2),
+                    makeCoordinateEditor(buildContext.getPlayer(), Coord.CopyB, CoordComponent.Z)
+                };
+            }
 
             Column columnRight, columnLessRight;
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMRenderer.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMRenderer.java
@@ -416,7 +416,7 @@ public class MMRenderer {
             if (isPasteValid) {
                 Objects.requireNonNull(paste);
 
-                pasteDeltas = state.config.getPasteVisualDeltas(player.worldObj, true);
+                pasteDeltas = state.config.getPasteVisualDeltas(player.worldObj, state.config.placeMode == PlaceMode.COPYING);
 
                 if (pasteDeltas == null) {
                     pasteDeltas = new VoxelAABB(paste.toVec(), paste.toVec());

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/networking/Messages.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/networking/Messages.java
@@ -117,6 +117,23 @@ public enum Messages {
         state.config.coordBOffset = null;
         state.config.coordCOffset = new Vector3i();
     }))),
+    SwapRegion(server(simple((player, stack, manipulator, state) -> {
+        Location coordA = state.config.coordA;
+        Location coordB = state.config.coordB;
+        Location coordC = state.config.coordC;
+
+        if (coordA == null || coordB == null || coordC == null) return;
+
+        Vector3i newCoordBVector = new Vector3i(
+            coordC.x + coordB.x - coordA.x,
+            coordC.y + coordB.y - coordA.y,
+            coordC.z + coordB.z - coordA.z
+        );
+
+        state.config.coordA = coordC;
+        state.config.coordB = new Location(player.worldObj, newCoordBVector);
+        state.config.coordC = coordA;
+    }))),
     MoveAll(server(simple((player, stack, manipulator, state) -> {
         state.config.action = PendingAction.MOVING_COORDS;
 

--- a/src/main/resources/assets/matter-manipulator/lang/en_US.lang
+++ b/src/main/resources/assets/matter-manipulator/lang/en_US.lang
@@ -224,6 +224,7 @@ mm.transform.button.flip_x=Flip X
 mm.transform.button.flip_y=Flip Y
 mm.transform.button.flip_z=Flip Z
 mm.transform.button.reset=Reset
+mm.transform.button.swap=Swap Region
 mm.transform.header.copy=Copy
 mm.transform.header.copy_a=Copy (A)
 mm.transform.header.copy_b=Copy (B)


### PR DESCRIPTION
## Summary
Add `Edit Transform` option to Move Mode
The transform window in move-mode also comes with the `Swap Region` button to swap between the cut region and paste region

Also enforce default transform when rendering paste region because move mode doesn't allow for transformation in the first place

https://github.com/user-attachments/assets/0be2b94b-ff8f-4bbc-abd7-f1dd6b6100c1


Closes GTNewHorizons/GT-New-Horizons-Modpack#22047
Closes GTNewHorizons/GT-New-Horizons-Modpack#24653

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
