### PR TITLE
feat: support forestry woods

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,6 +43,7 @@ def carpenters = false
 def avaritia = false
 def eio = false
 def fl = false
+def forestry = false
 def xu = false
 def fmp = false
 def gt5u = false
@@ -112,6 +113,8 @@ dependencies {
     addCompat(xu, rfg.deobf("curse.maven:extra-utilities-225561:2264384"))
 
     addCompat(fl, "com.github.GTNewHorizons:FloodLights:1.5.6:dev")
+
+    addCompat(forestry, "com.github.GTNewHorizons:ForestryMC:4.11.31:dev")
 
     addCompat(fmp, rfg.deobf("maven.modrinth:immibis-microblocks:59.1.2"))
     addCompat(fmp, rfg.deobf("maven.modrinth:immibis-core:59.1.4"))

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -79,6 +79,9 @@ import codechicken.enderstorage.storage.item.TileEnderChest;
 import codechicken.enderstorage.storage.liquid.TileEnderTank;
 import de.keridos.floodlights.tileentity.TileEntityMetaFloodlight;
 import de.keridos.floodlights.tileentity.TileEntitySmallFloodlight;
+import forestry.arboriculture.blocks.BlockRegistryArboriculture;
+import forestry.arboriculture.tiles.TileWood;
+import forestry.plugins.PluginArboriculture;
 import gcewing.architecture.common.tile.TileArchitecture;
 import ic2.api.tile.IWrenchable;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
@@ -267,6 +270,7 @@ public class BlockPropertyRegistry {
         if (Mods.IndustrialCraft2.isModLoaded()) initIC2();
         if (Mods.ArchitectureCraft.isModLoaded()) initArch();
         if (Mods.FloodLights.isModLoaded()) initFloodLights();
+        if (Mods.Forestry.isModLoaded()) initForestry();
         if (Mods.GregTech.isModLoaded()) initGT5u();
         if (Mods.AppliedEnergistics2.isModLoaded()) initAE2Wireless();
         if (Mods.EnderStorage.isModLoaded()) initEnderStorage();
@@ -1065,6 +1069,74 @@ public class BlockPropertyRegistry {
                 world.markBlockForUpdate(x, y, z);
             }
         });
+    }
+
+    // #endregion
+
+    // #region Forestry
+
+    @Optional(Names.FORESTRY)
+    private static void initForestry() {
+        ForestryWoodTypeProperty property = new ForestryWoodTypeProperty();
+
+        BlockRegistryArboriculture blocks = PluginArboriculture.blocks;
+
+        registerIntrinsicProperty(blocks.logs, property);
+        registerIntrinsicProperty(blocks.logsFireproof, property);
+        registerIntrinsicProperty(blocks.planks, property);
+        registerIntrinsicProperty(blocks.planksFireproof, property);
+        registerIntrinsicProperty(blocks.slabs, property);
+        registerIntrinsicProperty(blocks.slabsDouble, property);
+        registerIntrinsicProperty(blocks.slabsFireproof, property);
+        registerIntrinsicProperty(blocks.slabsDoubleFireproof, property);
+        registerIntrinsicProperty(blocks.fences, property);
+        registerIntrinsicProperty(blocks.fencesFireproof, property);
+        registerIntrinsicProperty(blocks.stairs, property);
+        registerIntrinsicProperty(blocks.stairsFireproof, property);
+    }
+
+    /*
+     * Forestry always places wood blocks (planks, logs, slabs, fences, stairs) with metadata 0 and instead stores
+     * the real wood type in the {@link TileWood} tile entity.
+     */
+    private static class ForestryWoodTypeProperty implements IntrinsicProperty {
+
+        @Override
+        public String getName() {
+            return "woodType";
+        }
+
+        @Override
+        public boolean hasValue(ItemStack stack) {
+            return stack != null;
+        }
+
+        @Override
+        public boolean hasValue(IBlockAccess world, int x, int y, int z) {
+            return world.getTileEntity(x, y, z) instanceof TileWood;
+        }
+
+        @Override
+        public JsonElement getValue(ItemStack stack) {
+            return new JsonPrimitive(stack.getItemDamage());
+        }
+
+        @Override
+        public JsonElement getValue(IBlockAccess world, int x, int y, int z) {
+            if (!(world.getTileEntity(x, y, z) instanceof TileWood wood)) return null;
+
+            return new JsonPrimitive(wood.getWoodType().ordinal());
+        }
+
+        @Override
+        public void setValue(ItemStack stack, JsonElement value) {
+            stack.setItemDamage(value.getAsInt());
+        }
+
+        @Override
+        public void setValue(IBlockAccess world, int x, int y, int z, JsonElement value) {
+            throw new UnsupportedOperationException("Wood type is immutable for in-world blocks");
+        }
     }
 
     // #endregion

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -29,6 +29,7 @@ public enum Mods implements IMod, ITargetMod {
     /** The forge multipart library. */
     ForgeMultipart(Names.FORGE_MULTIPART),
     FloodLights(Names.FLOOD_LIGHTS),
+    Forestry(Names.FORESTRY),
     GalacticraftCore(Names.GALACTICRAFT_CORE),
     GalaxySpace(Names.GALAXY_SPACE),
     GregTech(Names.GREG_TECH) {
@@ -75,6 +76,7 @@ public enum Mods implements IMod, ITargetMod {
         public static final String FORGE_MICROBLOCKS = "ForgeMicroblock";
         public static final String FORGE_MULTIPART = "ForgeMultipart";
         public static final String FLOOD_LIGHTS = "FloodLights";
+        public static final String FORESTRY = "Forestry";
         public static final String GALACTICRAFT_CORE = "GalacticraftCore";
         public static final String GALAXY_SPACE = "GalaxySpace";
         public static final String GREG_TECH = "gregtech";


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Adding support for Forestry wood tile entities. Wood type is stored in `TileWood` NBT, not in metadata.

> [!WARNING]
> Depends on https://github.com/GTNewHorizons/ForestryMC/pull/127 to work with slabs (not needed for merge)

> [!NOTE]
> This does not support leaves or saplings. I could add those if need comes later. 

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
