### PR TITLE
Add Dynamism Tablet compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -126,6 +126,9 @@ dependencies {
     addCompat(tc, "thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     addCompat(tc, "com.github.GTNewHorizons:ThaumicEnergistics:1.7.56-GTNH:dev")
 
+    compileOnly("curse.maven:computercraft-67504:2269339", { transitive = false })
+    addCompat(tc, "com.github.GTNewHorizons:ThaumicTinkerer:2.12.28:dev")
+
     addCompat(waila, "com.github.GTNewHorizons:waila:1.19.30:dev")
 }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -89,6 +89,7 @@ import li.cil.oc.common.item.data.TransposerData;
 import li.cil.oc.common.tileentity.Transposer;
 import li.cil.oc.common.tileentity.traits.Rotatable;
 import lombok.SneakyThrows;
+import thaumic.tinkerer.common.block.tile.tablet.TileAnimationTablet;
 
 public class BlockPropertyRegistry {
 
@@ -272,6 +273,7 @@ public class BlockPropertyRegistry {
         if (Mods.EnderStorage.isModLoaded()) initEnderStorage();
         if (Mods.ExtraUtilities.isModLoaded()) initEXU();
         if (Mods.OpenComputers.isModLoaded()) initOpenComputers();
+        if (Mods.ThaumicTinkerer.isModLoaded()) initThaumicTinkerer();
     }
 
     // #region Vanilla
@@ -1286,6 +1288,76 @@ public class BlockPropertyRegistry {
                 }
             }
         );
+    }
+
+    // #endregion
+
+    // #region ThaumicTinkerer
+
+    @Optional(Names.THAUMIC_TINKERER)
+    private static void initThaumicTinkerer() {
+        registerTileEntityInterfaceProperty(TileAnimationTablet.class, new AbstractDirectionBlockProperty("facing") {
+
+            @Override
+            public ForgeDirection getValue(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileAnimationTablet tablet)) return UNKNOWN;
+
+                return ForgeDirection.getOrientation(tablet.getBlockMetadata());
+            }
+
+            @Override
+            public void setValue(World world, int x, int y, int z, ForgeDirection forgeDirection) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileAnimationTablet tablet)) return;
+
+                world.setBlockMetadataWithNotify(x, y, z, forgeDirection.ordinal(), 1 | 2);
+            }
+        });
+
+        registerTileEntityInterfaceProperty(TileAnimationTablet.class, new BooleanProperty() {
+
+            @Override
+            public String getName() {
+                return "mode";
+            }
+
+            @Override
+            public boolean getBoolean(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileAnimationTablet tablet)) return false;
+
+                return tablet.leftClick;
+            }
+
+            @Override
+            public void setBoolean(World world, int x, int y, int z, boolean value) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileAnimationTablet tablet)) return;
+
+                tablet.leftClick = value;
+                world.markBlockForUpdate(x, y, z);
+            }
+        });
+
+        registerTileEntityInterfaceProperty(TileAnimationTablet.class, new BooleanProperty() {
+
+            @Override
+            public String getName() {
+                return "inverted";
+            }
+
+            @Override
+            public boolean getBoolean(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileAnimationTablet tablet)) return false;
+
+                return tablet.redstone;
+            }
+
+            @Override
+            public void setBoolean(World world, int x, int y, int z, boolean value) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileAnimationTablet tablet)) return;
+
+                tablet.redstone = value;
+                world.markBlockForUpdate(x, y, z);
+            }
+        });
     }
 
     // #endregion

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -1309,7 +1309,10 @@ public class BlockPropertyRegistry {
             public void setValue(World world, int x, int y, int z, ForgeDirection forgeDirection) {
                 if (!(world.getTileEntity(x, y, z) instanceof TileAnimationTablet tablet)) return;
 
-                world.setBlockMetadataWithNotify(x, y, z, forgeDirection.ordinal(), 1 | 2);
+                int ordinal = forgeDirection.ordinal();
+                if (ordinal < 2) return;
+
+                world.setBlockMetadataWithNotify(x, y, z, ordinal, 1 | 2);
             }
         });
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -57,6 +57,7 @@ public enum Mods implements IMod, ITargetMod {
     NotEnoughItems(Names.NOT_ENOUGH_ITEMS),
     StorageDrawers(Names.STORAGE_DRAWERS),
     Thaumcraft(Names.THAUMCRAFT),
+    ThaumicTinkerer(Names.THAUMIC_TINKERER)
 
     ;
 
@@ -93,6 +94,7 @@ public enum Mods implements IMod, ITargetMod {
         public static final String STORAGE_DRAWERS = "StorageDrawers";
         public static final String THAUMCRAFT = "Thaumcraft";
         public static final String THAUMIC_ENERGISTICS = "thaumicenergistics";
+        public static final String THAUMIC_TINKERER = "ThaumicTinkerer";
     }
 
     public final String ID;


### PR DESCRIPTION
## Summary
Add compat to dynamism tablet (thaumic tinkerer) to copy the rotation, left click mode, and redstone control property

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
