### PR TITLE
Custom Ender Storage consumer

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/MMItemConsumer.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/MMItemConsumer.java
@@ -4,6 +4,7 @@ import java.util.Comparator;
 
 import com.recursive_pineapple.matter_manipulator.common.building.consumers.AECableItemConsumer;
 import com.recursive_pineapple.matter_manipulator.common.building.consumers.DefaultItemConsumer;
+import com.recursive_pineapple.matter_manipulator.common.building.consumers.EnderStorageItemConsumer;
 import com.recursive_pineapple.matter_manipulator.common.building.consumers.IItemConsumer;
 import com.recursive_pineapple.matter_manipulator.common.utils.BigItemStack;
 import com.recursive_pineapple.matter_manipulator.common.utils.Mods;
@@ -35,6 +36,9 @@ public class MMItemConsumer {
         registerConsumer(Integer.MIN_VALUE, new DefaultItemConsumer());
         if (Mods.AppliedEnergistics2.isModLoaded()) {
             registerConsumer(0, new AECableItemConsumer());
+        }
+        if (Mods.EnderStorage.isModLoaded()) {
+            registerConsumer(0, new EnderStorageItemConsumer());
         }
     }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
@@ -1,0 +1,119 @@
+package com.recursive_pineapple.matter_manipulator.common.building.consumers;
+
+import static com.recursive_pineapple.matter_manipulator.common.building.IPseudoInventory.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import net.minecraftforge.common.util.Constants;
+
+import com.recursive_pineapple.matter_manipulator.common.building.IPseudoInventory;
+import com.recursive_pineapple.matter_manipulator.common.building.InteropConstants;
+import com.recursive_pineapple.matter_manipulator.common.utils.BigItemStack;
+
+import codechicken.enderstorage.EnderStorage;
+
+/**
+ * A consumer that can consume Ender Chest/Tank with any color and setting
+ */
+public class EnderStorageItemConsumer implements IItemConsumer {
+
+    @Override
+    public void consume(IPseudoInventory inv, BigItemStack in, BigItemStack out, int flags) {
+        if (InteropConstants.ENDER_STORAGE.getItem() != in.getItem()) return;
+
+        boolean isTank = in.meta >= 4096;
+        boolean isPrivate = in.tag != null && in.tag.hasKey("owner", Constants.NBT.TAG_STRING);
+        boolean isPlanning = (flags & CONSUME_SIMULATED) == 1 && (flags & CONSUME_IGNORE_CREATIVE) == 1;
+
+        long initial = in.getStackSize();
+        long specialAmount = 0;
+
+        List<BigItemStack> toExtract = new ArrayList<>();
+        List<BigItemStack> specialStacks = new ArrayList<>();
+
+        // Start searching from frequency 0
+        for (int freq = 0; freq < 4096; freq++) {
+            // We're in planning and freq 0 is used for crafting, skip it
+            if (isPlanning && freq == 0) continue;
+
+            BigItemStack simulateStack = in.copy();
+            simulateStack.meta = isTank ? 4096 + freq : freq;
+            simulateStack.tag = null;
+
+            List<BigItemStack> extractSimulated = inv.tryConsumeItems(
+                Collections.singletonList(simulateStack),
+                CONSUME_FUZZY | CONSUME_PARTIAL | CONSUME_SIMULATED | flags
+            ).right();
+
+            if (extractSimulated != null) {
+                for (BigItemStack extracted : extractSimulated) {
+                    boolean isExtractedPrivate = extracted.tag != null &&
+                        extracted.tag.hasKey("owner", Constants.NBT.TAG_STRING);
+
+                    if (isPrivate == isExtractedPrivate) {
+                        in.decStackSize(extracted.getStackSize());
+                        toExtract.add(extracted);
+                    } else {
+                        specialStacks.add(extracted);
+                        specialAmount += extracted.stackSize;
+                    }
+                }
+
+                if (in.getStackSize() <= 0) break;
+            }
+        }
+
+        specialAmount = Math.min(in.getStackSize(), specialAmount);
+
+        if (specialAmount > 0) {
+            if (isPrivate) {
+                BigItemStack personalItem = BigItemStack.create(EnderStorage.getPersonalItem())
+                    .setStackSize(specialAmount);
+                List<BigItemStack> personalItems = inv.tryConsumeItems(
+                    Collections.singletonList(personalItem),
+                    CONSUME_PARTIAL | flags
+                ).right();
+
+                if (personalItems != null && !personalItems.isEmpty()) {
+                    specialAmount = personalItems.get(0).getStackSize();
+                }
+            }
+
+            long initialSpecialAmount = specialAmount;
+
+            for (BigItemStack stack : specialStacks) {
+                long size = Math.min(specialAmount, stack.getStackSize());
+
+                stack.setStackSize(size);
+                toExtract.add(stack);
+                in.decStackSize(size);
+                specialAmount -= size;
+
+                if (in.getStackSize() <= 0) break;
+                if (specialAmount <= 0) break;
+            }
+
+            specialAmount = initialSpecialAmount - specialAmount;
+        }
+
+        boolean success = inv.tryConsumeItems(toExtract, flags).leftBoolean();
+
+        if (!success) {
+            // Something gone wrong, reset to former state
+            in.setStackSize(initial);
+        } else {
+            out.incStackSize(initial - in.getStackSize());
+        }
+
+        if ((!success && isPrivate) || (success && !isPrivate) && !isPlanning) {
+            // Give player personalItems if success and not private
+            // or return personalItems if private and failed
+
+            BigItemStack personalItem = BigItemStack.create(EnderStorage.getPersonalItem())
+                .setStackSize(specialAmount);
+            inv.givePlayerItems(Collections.singletonList(personalItem));
+        }
+    }
+}

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
@@ -49,9 +49,6 @@ public class EnderStorageItemConsumer implements IItemConsumer {
                     boolean isExtractedPrivate = extracted.tag != null &&
                         extracted.tag.hasKey("owner", Constants.NBT.TAG_STRING);
 
-                    // We're in planning and freq 0 non-private is used for crafting, skip it
-                    if (isPlanning && !isExtractedPrivate && freq == 0) continue;
-
                     if (isPrivate == isExtractedPrivate) {
                         in.decStackSize(extracted.getStackSize());
                         toExtract.add(extracted);
@@ -110,7 +107,7 @@ public class EnderStorageItemConsumer implements IItemConsumer {
         }
 
         boolean shouldReturnPersonalItem = (!success && isPrivate) || (success && !isPrivate);
-        if (!isPlanning && shouldReturnPersonalItem) {
+        if (shouldReturnPersonalItem && (flags & CONSUME_SIMULATED) == 0) {
             // Give player personalItems if success and not private
             // or return personalItems if private and failed
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
@@ -25,7 +25,6 @@ public class EnderStorageItemConsumer implements IItemConsumer {
 
         boolean isTank = in.meta >= 4096;
         boolean isPrivate = in.tag != null && in.tag.hasKey("owner", Constants.NBT.TAG_STRING);
-        boolean isPlanning = (flags & CONSUME_SIMULATED) == 1 && (flags & CONSUME_IGNORE_CREATIVE) == 1;
 
         long initial = in.getStackSize();
         long specialAmount = 0;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/consumers/EnderStorageItemConsumer.java
@@ -35,9 +35,6 @@ public class EnderStorageItemConsumer implements IItemConsumer {
 
         // Start searching from frequency 0
         for (int freq = 0; freq < 4096; freq++) {
-            // We're in planning and freq 0 is used for crafting, skip it
-            if (isPlanning && freq == 0) continue;
-
             BigItemStack simulateStack = in.copy();
             simulateStack.meta = isTank ? 4096 + freq : freq;
             simulateStack.tag = null;
@@ -51,6 +48,9 @@ public class EnderStorageItemConsumer implements IItemConsumer {
                 for (BigItemStack extracted : extractSimulated) {
                     boolean isExtractedPrivate = extracted.tag != null &&
                         extracted.tag.hasKey("owner", Constants.NBT.TAG_STRING);
+
+                    // We're in planning and freq 0 non-private is used for crafting, skip it
+                    if (isPlanning && !isExtractedPrivate && freq == 0) continue;
 
                     if (isPrivate == isExtractedPrivate) {
                         in.decStackSize(extracted.getStackSize());
@@ -78,6 +78,8 @@ public class EnderStorageItemConsumer implements IItemConsumer {
 
                 if (personalItems != null && !personalItems.isEmpty()) {
                     specialAmount = personalItems.get(0).getStackSize();
+                } else {
+                    specialAmount = 0;
                 }
             }
 
@@ -107,7 +109,8 @@ public class EnderStorageItemConsumer implements IItemConsumer {
             out.incStackSize(initial - in.getStackSize());
         }
 
-        if ((!success && isPrivate) || (success && !isPrivate) && !isPlanning) {
+        boolean shouldReturnPersonalItem = (!success && isPrivate) || (success && !isPrivate);
+        if (!isPlanning && shouldReturnPersonalItem) {
             // Give player personalItems if success and not private
             // or return personalItems if private and failed
 


### PR DESCRIPTION
## Summary
Allow Ender Chest/Tank to be consumed regardless of frequency/owner setting


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
