### PR TITLE
Don't config fuzzy mode if fuzzy card is not present to avoid nbt pollution

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/AECellItemProvider.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/providers/AECellItemProvider.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
 import appeng.api.config.FuzzyMode;
+import appeng.api.config.Upgrades;
 import appeng.api.definitions.IItemDefinition;
 import appeng.api.storage.ICellWorkbenchItem;
 import appeng.parts.automation.UpgradeInventory;
@@ -117,16 +118,23 @@ public class AECellItemProvider implements IItemProvider {
             config.markDirty();
         }
 
-        cellWorkbenchItem.setFuzzyMode(cell, switch (mFuzzyMode) {
-            case 0 -> FuzzyMode.IGNORE_ALL;
-            case 1 -> FuzzyMode.PERCENT_25;
-            case 2 -> FuzzyMode.PERCENT_50;
-            case 3 -> FuzzyMode.PERCENT_75;
-            case 4 -> FuzzyMode.PERCENT_99;
-            case 5 -> FuzzyMode.PERCENT_10;
-            case 6 -> FuzzyMode.PERCENT_1;
-            default -> FuzzyMode.IGNORE_ALL;
-        });
+        boolean hasFuzzyCard = false;
+        if (upgrades != null) {
+            hasFuzzyCard = upgrades.getInstalledUpgrades(Upgrades.FUZZY) >= 1;
+        }
+
+        if (hasFuzzyCard) {
+            cellWorkbenchItem.setFuzzyMode(cell, switch (mFuzzyMode) {
+                case 0 -> FuzzyMode.IGNORE_ALL;
+                case 1 -> FuzzyMode.PERCENT_25;
+                case 2 -> FuzzyMode.PERCENT_50;
+                case 3 -> FuzzyMode.PERCENT_75;
+                case 4 -> FuzzyMode.PERCENT_99;
+                case 5 -> FuzzyMode.PERCENT_10;
+                case 6 -> FuzzyMode.PERCENT_1;
+                default -> FuzzyMode.IGNORE_ALL;
+            });
+        }
 
         IItemDefinition oredictCard = AEApi.instance()
             .definitions()


### PR DESCRIPTION
## Summary
Don't config fuzzy mode if fuzzy card is not present to avoid nbt pollution. Copying inventory with empty ae2 cells will now create cells with completely empty nbt in them after the change instead of having a fuzzy mode set.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
